### PR TITLE
[Kids on bikes] add roll button names

### DIFF
--- a/Kids-on-Bikes/kob.html
+++ b/Kids-on-Bikes/kob.html
@@ -31,7 +31,7 @@
       <div class="sheet-startcol" style="width: 25%;">
         <div style="margin-left: 0%;">
           <input class="sheet-attrnum" type="text" name="attr_fight">
-          <button type="roll" value="** @{character_name} ** rolls a **FIGHT** check getting: [[@{fight}]] "> </button>
+          <button type="roll" name="fight" value="** @{character_name} ** rolls a **FIGHT** check getting: [[@{fight}]] "> </button>
           <label><img src="https://i.imgur.com/YWJ7tXT.png" width="40" height="22" alt=""/></label>
           <input class="sheet-attrnum" type="text" name="attr_brains">
           <button type="roll" value="** @{character_name} ** rolls a **BRAINS** check getting: [[@{brains}]]"> </button>


### PR DESCRIPTION
If roll buttons are given names, in this way, they can be dragged and dropped to the users button bar at the botton of the screen and can be rolled from there without needing to open the character sheet, nor needing to write macros for each one.